### PR TITLE
Update monero-wallet-generator-print.html

### DIFF
--- a/monero-wallet-generator-print.html
+++ b/monero-wallet-generator-print.html
@@ -11009,13 +11009,13 @@ function genwallet(lang)
   }
   else if (prefix_widget.value[0] == "W") {
     qr=new QRCode(address_qr_widget, {correctLevel:QRCode.CorrectLevel.L});
-    qr.makeCode("aeonAddress:"+keys.public_addr);
+    qr.makeCode(keys.public_addr);
     
     qr=new QRCode(privSpend_qr_widget, {correctLevel:QRCode.CorrectLevel.L});
-    qr.makeCode("aeonPrivSpend:"+keys.spend.sec);
+    qr.makeCode(keys.spend.sec);
     
     qr=new QRCode(privView_qr_widget, {correctLevel:QRCode.CorrectLevel.L});
-    qr.makeCode("aeonPrivView:"+keys.view.sec);
+    qr.makeCode(keys.view.sec);
   }
 }
 


### PR DESCRIPTION
Removed "AeonAddress:", "spendkey:", and "privatekey:" from the QR codes. When you scan a QR code, you know what you're scanning. It is not necessary and gets in the way if you're trying to copy the address to somebody who wants to send you coins, or if you're trying to copy the private key to spend coins.